### PR TITLE
Fix missing comma in armor list

### DIFF
--- a/lootz edit.py
+++ b/lootz edit.py
@@ -241,7 +241,7 @@ while True:
                         'Black Iron Banded', 'Glassteel Banded', 'Ironwood Banded', 'Orichalcon Banded', 'Black Iron Plate', 'Ironwood Plate', 
                         'Black Iron Plate', 'Deep Crystal Plate', 'Glassteel Plate', 'Ironwood Plate', 'Orichalcon Plate', 'Warpstone Plate', 
                         'Orichalcon Plate', "Unique Ancient's Plate", "Unique Ancient's Plate", "Unique Ancient's Plate", 
-                        'Mithril Plate', 'Adamantine Banded', 'Adamantine Plate', 'Dragonsteel Plate''Mithril Plate', 'Adamantine Banded', 'Adamantine Plate', 
+                        'Mithril Plate', 'Adamantine Banded', 'Adamantine Plate', 'Dragonsteel Plate', 'Mithril Plate', 'Adamantine Banded', 'Adamantine Plate',
                         'Dragonsteel Plate', 'Dragonsteel Plate', 'Dragonsteel Plate']
         
         # normal armor list


### PR DESCRIPTION
## Summary
- fix missing comma in magic armor list to prevent string concatenation

## Testing
- `python -m py_compile 'lootz edit.py'`

------
https://chatgpt.com/codex/tasks/task_e_683f693c06bc8327aeb5ef9f8e0c69b2