### PR TITLE
Simplify loot display

### DIFF
--- a/lootz 3.8.py
+++ b/lootz 3.8.py
@@ -2177,26 +2177,23 @@ def _split_sections(text):
     return sections
 
 
+def format_sections(text):
+    """Return the loot sections joined by blank lines."""
+    return "\n\n".join(_split_sections(text))
+
+
 def run_hoard(level, count=5):
     """Generate multiple sets of loot for a treasure hoard."""
-    aggregated = [[] for _ in LootzApp.SECTION_LABELS]
+    sets = []
     for _ in range(count):
-        for idx, part in enumerate(_split_sections(run_loot(level))):
-            if idx < len(aggregated):
-                aggregated[idx].append(part)
-    return ['\n\n'.join(parts) for parts in aggregated]
+        sets.append(format_sections(run_loot(level)))
+    return "\n\n".join(sets)
 
 
 class LootzApp(tk.Tk):
     """Simple Tkinter GUI for the loot generator."""
 
-    SECTION_LABELS = [
-        "Coins",
-        "Gems / Art",
-        "Consumables",
-        "Magic Items",
-        "Incidental Items",
-    ]
+    SECTION_LABELS = ["All Loot"]
 
     def __init__(self):
         super().__init__()
@@ -2212,28 +2209,19 @@ class LootzApp(tk.Tk):
         btn_frame.pack(pady=5)
         tk.Button(btn_frame, text='Generate Loot', command=self.generate).pack(side=tk.LEFT, padx=5)
         tk.Button(btn_frame, text='Generate Magic Item', command=self.generate_magic).pack(side=tk.LEFT, padx=5)
-
         tk.Button(btn_frame, text='Generate Hoard', command=self.generate_hoard).pack(side=tk.LEFT, padx=5)
-        # create two-column pane layout for the sections
-        self.paned = tk.PanedWindow(self, orient=tk.HORIZONTAL)
-        self.paned.pack(fill=tk.BOTH, expand=True)
 
-        self.left_col = tk.PanedWindow(self.paned, orient=tk.VERTICAL)
-        self.right_col = tk.PanedWindow(self.paned, orient=tk.VERTICAL)
-        self.paned.add(self.left_col)
-        self.paned.add(self.right_col)
+        self.output_widget = scrolledtext.ScrolledText(self, width=120, height=25)
+        self.output_widget.pack(fill=tk.BOTH, expand=True)
 
-        self.section_widgets = []
-        half = (len(self.SECTION_LABELS) + 1) // 2
-        for idx, label in enumerate(self.SECTION_LABELS):
-            parent = self.left_col if idx < half else self.right_col
-            frame = tk.Frame(parent)
-            tk.Label(frame, text=label).pack(anchor='w')
-            # wider text boxes to better fit the enlarged window
-            txt = scrolledtext.ScrolledText(frame, width=60, height=6)
-            txt.pack(fill=tk.BOTH, expand=True)
-            parent.add(frame)
-            self.section_widgets.append(txt)
+    def generate(self):
+        """Generate a single set of loot."""
+        level = self.level_entry.get().strip()
+        if not level:
+            return
+        result = format_sections(run_loot(level))
+        self.output_widget.delete("1.0", tk.END)
+        self.output_widget.insert(tk.END, result)
 
 
 
@@ -2242,13 +2230,9 @@ class LootzApp(tk.Tk):
         level = self.level_entry.get().strip()
         if not level:
             return
-        sections = run_hoard(level)
-        for idx, widget in enumerate(self.section_widgets):
-            widget.delete("1.0", tk.END)
-            if idx < len(sections):
-                widget.insert(tk.END, sections[idx])
-            else:
-                widget.insert(tk.END, "")
+        result = run_hoard(level)
+        self.output_widget.delete("1.0", tk.END)
+        self.output_widget.insert(tk.END, result)
 
     def generate_magic(self):
         """Display a single magic item in the first pane."""
@@ -2256,9 +2240,8 @@ class LootzApp(tk.Tk):
         if not level:
             return
         result = run_magic_item(level)
-        for widget in self.section_widgets:
-            widget.delete('1.0', tk.END)
-        self.section_widgets[0].insert(tk.END, result)
+        self.output_widget.delete('1.0', tk.END)
+        self.output_widget.insert(tk.END, result)
 
 if __name__ == '__main__':
     app = LootzApp()


### PR DESCRIPTION
## Summary
- simplify loot pane to display all loot together
- join sections with blank lines using new helper
- update hoard generator and GUI methods

## Testing
- `python -m py_compile 'lootz 3.8.py'`

------
https://chatgpt.com/codex/tasks/task_e_684c2a8ac8208327a86a1c882efe5a48